### PR TITLE
DEV-14982 add deletion_protection variable for instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This modules creates the following resources:
 | cloud\_sql\_viewer\_members | The list of members to bind to sql viewer role | `list(string)` | `[]` | no |
 | database\_flags | List of Cloud SQL flags that are applied to the database server. See [more details](https://cloud.google.com/sql/docs/mysql/flags) | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
 | db\_name | name of the database | `string` | `"doit"` | no |
+| deletion\_protection | Set deletion protection on Cloud SQL instance. Unless this field is set to false, a terraform destroy or terraform apply command that deletes the instance will fail. | `bool` | `true` | no |
 | disk\_autoresize | Enable disk to autoresize itself | `bool` | `true` | no |
 | disk\_size | size of the disk to use | `number` | `100` | no |
 | disk\_type | The disk type to use on the instance. should be either PD\_SSD or PD\_STANDARD | `string` | `"PD_SSD"` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "google_sql_database_instance" "tamr" {
   # NOTE: this is pinned as its the version that tamr needs
   database_version = "POSTGRES_12"
 
+  deletion_protection = var.deletion_protection
 
   settings {
     tier              = var.tier

--- a/variables.tf
+++ b/variables.tf
@@ -113,3 +113,9 @@ variable "database_flags" {
   }))
   default = []
 }
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Set deletion protection on Cloud SQL instance. Unless this field is set to false, a terraform destroy or terraform apply command that deletes the instance will fail."
+  default     = true
+}


### PR DESCRIPTION
Need `deletion_protection` to be plumbed through to gcp wrapper module so I can delete resources in https://github.com/Datatamer/tf-gcp-internal-scale/pull/20