### PR TITLE
revert iam member resource from_each to count and index

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,3 @@
-locals {
-  viewer_members = var.cloud_sql_viewer_members
-  client_members = var.cloud_sql_client_members
-  admin_members  = var.cloud_sql_admin_members
-}
-
 resource "google_project_service" "enable_sql" {
   project = var.project_id
   service = "sqladmin.googleapis.com"
@@ -99,23 +93,23 @@ resource "google_sql_user" "sql_dev_user" {
 
 # IAM
 resource "google_project_iam_member" "cloud_sql_viewer" {
-  count   = length(local.viewer_members)
+  count   = length(var.cloud_sql_viewer_members)
   project = var.project_id
   role    = "roles/cloudsql.viewer"
-  member  = local.viewer_members[count.index]
+  member  = var.cloud_sql_viewer_members[count.index]
 }
 
 resource "google_project_iam_member" "cloud_sql_client" {
-  count   = length(local.client_members)
+  count   = length(var.cloud_sql_client_members)
   project = var.project_id
   role    = "roles/cloudsql.client"
-  member  = local.client_members[count.index]
+  member  = var.cloud_sql_client_members[count.index]
 }
 
 # NOTE: this is needed for backups to work
 resource "google_project_iam_member" "cloud_sql_admin" {
-  count   = length(local.admin_members)
+  count   = length(var.cloud_sql_admin_members)
   project = var.project_id
   role    = "roles/cloudsql.admin"
-  member  = local.admin_members[count.index]
+  member  = var.cloud_sql_admin_members[count.index]
 }


### PR DESCRIPTION
This PR aims to address the apparent bug that seems to have been introduced in cloud sql module between v2.1.0 and v4.6.0 that was encountered here: https://github.com/Datatamer/tf-gcp-internal-scale/pull/20#issuecomment-902028575

When using `for_each` on a set of strings, they must all be _known values_ (https://www.terraform.io/docs/language/meta-arguments/for_each.html#limitations-on-values-used-in-for_each).
This is a limitation when using a variable parameter with `for_each`.

This PR reverts this portion of the module to use `count` instead of `for_each`, as was done prior to v3.0.0.
See related discussion here: https://discuss.hashicorp.com/t/the-for-each-value-depends-on-resource-attributes-that-cannot-be-determined-until-apply/25016