### PR TITLE
MINOR: SRE-3220: ignore lifecycle changes for backup location

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,12 @@ resource "google_sql_database_instance" "tamr" {
 
   deletion_protection = var.deletion_protection
 
+  lifecycle {
+    ignore_changes = [
+      settings[0].backup_configuration[0].location,
+    ]
+  }
+
   settings {
     tier              = var.tier
     disk_size         = var.disk_size


### PR DESCRIPTION
https://cloud.google.com/sql/docs/mysql/backup-recovery/backups#default-backup-location